### PR TITLE
added signals and recorder to Decorator props

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,14 @@ Factory.Decorator = function (paths) {
         return paths || {};
       },
       render: function () {
-        return React.createElement(Component, this.state);
+        var state = this.state;
+        var props = Object.keys(state).reduce(function (props, key) {
+          props[key] = state[key];
+          return props;
+        }, {});
+        props.signals = this.signals;
+        props.recorder = this.recorder;
+        return React.createElement(Component, props);
       }
     });
   };

--- a/index.js
+++ b/index.js
@@ -112,6 +112,16 @@ Factory.Mixin = {
       return newState;
     }, {});
     this.setState(newState);
+  },
+  _getControllerProps : function(){
+    var state = this.state;
+    var props = Object.keys(state).reduce(function (props, key) {
+      props[key] = state[key];
+      return props;
+    }, {});
+    props.signals = this.signals;
+    props.recorder = this.recorder;
+    return props;
   }
 };
 
@@ -124,13 +134,7 @@ Factory.Decorator = function (paths) {
         return paths || {};
       },
       render: function () {
-        var state = this.state;
-        var props = Object.keys(state).reduce(function (props, key) {
-          props[key] = state[key];
-          return props;
-        }, {});
-        props.signals = this.signals;
-        props.recorder = this.recorder;
+        var props = this._getControllerProps.apply(this);
         return React.createElement(Component, props);
       }
     });
@@ -144,13 +148,7 @@ Factory.HOC = function (Component, paths) {
       return paths || {};
     },
     render: function () {
-      var state = this.state;
-      var props = Object.keys(state).reduce(function (props, key) {
-        props[key] = state[key];
-        return props;
-      }, {});
-      props.signals = this.signals;
-      props.recorder = this.recorder;
+      var props = this._getControllerProps.apply(this);
       return React.createElement(Component, props);
     }
   });


### PR DESCRIPTION
Hi christian! 
First of all i have to thank you for what you've done so far! This is whole cerebral thing is really impressive. I am also a big fan of global immutable state and i am really looking forward using your framework . Keep up that good work!

Now to the issue:
In the Decorator the recorder and the signals are missing. Is this intentional? If not I have created a pull request to fix this. ~~~Maybe I could also move it into the `Mixin` if you like. (for the sake of DRY)~~~ I have put the functionality in a function into the `Mixin` because I couldn't stand it ;)

Best Regards,
Mathias
